### PR TITLE
daed/files: 修复 daed 守护进程的停止与重启流程

### DIFF
--- a/daed/Makefile
+++ b/daed/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=daed
 PKG_VERSION:=2026.09.06
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=daed-src-2026.09.06-00979296e45e.tar.gz
 PKG_SOURCE_URL:=https://github.com/kenzok8/openwrt-daede/releases/download/daed-src

--- a/daed/files/daed-cleanup.sh
+++ b/daed/files/daed-cleanup.sh
@@ -7,78 +7,57 @@
 #      umount+rm as fallback for zombie nsfs mounts)
 #   3. The `dae0` veth pair in the host netns
 #
-# What this script intentionally does NOT do:
+# daed itself owns TC clsact detach. This opkg-side helper only
+# reaps stale daens/dae0 state and never removes /sys/fs/bpf/daed.
+# The pin directory is created during normal startup, so it is not
+# a reliable leak indicator and must not block service lifecycle.
 #
-#   It does NOT try to detach the eBPF tc clsact filter that daed
-#   pins on br-lan / dae0 ingress. The detach path lives inside
-#   the daed userspace process itself (`ControlPlane.DetachBpfHooks`
-#   → `netlink.FilterDel` / `tc qdisc del dev <iface> clsact`,
-#   control/control_plane_core.go:228, control/bpf_purge.go:30-41).
-#   `bpftool prog detach` is the wrong tool: it only handles the
-#   attach types the kernel exposes through bpf_iter / bpf_link
-#   (sk_msg_verdict, sk_skb_verdict, sk_skb_stream_verdict,
-#   sk_skb_stream_parser, flow_dissector), and daed's hooks are
-#   attached via `netlink.FilterAdd` as TC clsact filters, which
-#   are not on that list. kenzok8 confirmed this on PR
-#   kenzok8/openwrt-daede#70 (review, 2026-09-06 12:37Z).
-#
-#   The honest summary of what an opkg-side wrapper can and cannot
-#   do for the eBPF-leak problem (daeuniverse/dae#1092):
-#
-#     CAN do:                                        CANNOT do:
-#     reap daens netns                                detach pinned tc clsact filters
-#     reap dae0 veth pair                             delete /sys/fs/bpf/daed cleanly
-#     refuse to start a second daed (see
-#     daed-guard's pgrep check)
-#
-#   The pinned-tc-clsact fix has to land in daed's own graceful
-#   shutdown path (which is already the case — see
-#   dae/cmd/run.go:1035), or in a separate kernel-level cleanup
-#   helper. The opkg wrapper's job is to make sure the netns/veth
-#   state is clean and to make a stale eBPF situation visible in
-#   logread so an operator knows a reboot is required.
-#
-# Idempotent: re-running on a clean system is a no-op. Safe to call
-# while daed is running — every potentially-destructive step is
-# guarded by a `pgrep -f /usr/bin/daed` check.
-#
-# Companion to daed-guard: that wrapper calls daed_cleanup_runtime
-# before exec'ing the daemon (so any stale state from a previous
-# crashed run is reaped) and again after the daemon exits (so a
-# OOM-kill or kernel panic also leaves the netns/veth clean).
-#
-# This script is a kenzok8/openwrt-daede-specific evolution of the
-# file originally shipped in daeuniverse/daed's `install/linux/`.
-# It must remain a single function (`daed_cleanup_runtime`) so the
-# `procd init.d/daed` and the `daed-guard` wrapper can both
-# source it.
+# The function stays sourceable by both init.d/daed and daed-guard.
+
+daed_process_probe() {
+	if command -v pgrep >/dev/null 2>&1; then
+		pgrep -f '^/usr/bin/daed([[:space:]]|$)' >/dev/null 2>&1
+		case "$?" in
+			0) return 0 ;;
+			1) return 1 ;;
+		esac
+	fi
+
+	if command -v pidof >/dev/null 2>&1; then
+		pidof daed >/dev/null 2>&1
+		case "$?" in
+			0) return 0 ;;
+			1) return 1 ;;
+		esac
+	fi
+
+	return 2
+}
 
 daed_cleanup_runtime() {
-	local pid rc=0
+	local pid rc=0 probe_rc
 
 	# If daed userspace is currently running, do not touch the
 	# netns, the veth, or the eBPF dataplane. They are in active
 	# use; removing them would make every connection through dae
 	# hang.
-	if pgrep -f '^/usr/bin/daed([[:space:]]|$)' >/dev/null 2>&1; then
+	daed_process_probe
+	probe_rc=$?
+	case "$probe_rc" in
+	0)
 		if [ "${DAED_GUARD_CLEANUP:-start}" = "start" ]; then
-			# Stale-child guard (P1-#6 in the Codex review on
-			# kenzok8/openwrt-daede#70): if we get here from
-			# daed-guard's pre-start cleanup, a previous wrapper
-			# was killed and its /usr/bin/daed child outlived it.
-			# Returning 1 makes the wrapper refuse to start a
-			# SECOND daed against the same eBPF dataplane.
 			logger -t daed-init "cleanup: pre-start skipped because /usr/bin/daed is still running; refusing a second instance"
 			return 1
 		fi
-
-		# A different daed instance may still be alive during a
-		# post-exit cleanup (for example, while procd is handling a
-		# stale wrapper). Do not touch its runtime state, but make
-		# the reason visible instead of silently reporting success.
 		logger -t daed-init "cleanup: post-exit skipped because another /usr/bin/daed instance is still running"
 		return 0
-	fi
+		;;
+	1) ;;
+	*)
+		logger -t daed-init "cleanup: cannot determine whether daed is running; refusing to remove netns/veth"
+		return 1
+		;;
+	esac
 
 	# 1. Kill processes inside daens.
 	for pid in $(ip netns pids daens 2>/dev/null); do
@@ -112,21 +91,15 @@ daed_cleanup_runtime() {
 		fi
 	fi
 
-	# 4. /sys/fs/bpf/daed is intentionally never removed here.
-	#    Pinned eBPF state may still represent an attached TC
-	#    clsact filter; unlinking it cannot detach that filter.
-	#    Retain the pins, log a diagnostic, and fail so the
-	#    pre-start guard blocks a second daemon.
+	# 4. The pin root is normal persistent state. Never remove it or
+	#    make its existence change the cleanup result.
 	if [ -e /sys/fs/bpf/daed ]; then
-		logger -t daed-init "cleanup: retaining /sys/fs/bpf/daed; pinned eBPF state requires manual recovery or reboot"
-		rc=1
+		logger -t daed-init "cleanup: /sys/fs/bpf/daed exists; leaving normal pin root unchanged"
 	fi
 
-	# Final verification. If any of these three still exist the
-	# caller will see a non-zero exit and can decide to reboot.
-	# (We do NOT check /sys/fs/bpf/daed here — see file header.)
+	# Final verification covers only netns and veth state.
 	[ ! -e /run/netns/daens ] || return 1
-	! ip netns list 2>/dev/null | awk '$1 == "daens" { found=1 } END { exit !found }' || return 1
+	! ip netns list 2>/dev/null | grep -Eq '^daens([[:space:]]|$)' || return 1
 	! ip link show dae0 >/dev/null 2>&1 || return 1
 
 	return $rc

--- a/daed/files/daed-cleanup.sh
+++ b/daed/files/daed-cleanup.sh
@@ -110,23 +110,14 @@ daed_cleanup_runtime() {
 		fi
 	fi
 
-	# 4. /sys/fs/bpf/daed bpffs. The eBPF programs inside are
-	#    owned by the daed userspace process; if daed is not
-	#    running (we already checked above) the pinned
-	#    programs are no longer attached, but the bpffs
-	#    directory may still exist. Removing the directory
-	#    here only unlinks the bpffs inode; it does NOT
-	#    detach a TC clsact filter (see the file header for
-	#    the full explanation). If the eBPF leak we hit on
-	#    2026-09-06 09:37 has happened, the tc clsact filter
-	#    is still attached to br-lan ingress even after this
-	#    rm, and a reboot is the only safe recovery. We do
-	#    best-effort cleanup so an operator's manual `rm
-	#    /sys/fs/bpf/daed` is not required.
-	if [ -d /sys/fs/bpf/daed ]; then
-		if ! rm -rf /sys/fs/bpf/daed 2>/dev/null; then
-			logger -t daed-init "cleanup: /sys/fs/bpf/daed still present after rm; this is harmless but indicates the eBPF leak path. Reboot if traffic is hijacked."
-		fi
+	# 4. /sys/fs/bpf/daed is intentionally never removed here.
+	#    Pinned eBPF state may still represent an attached TC
+	#    clsact filter; unlinking it cannot detach that filter.
+	#    Retain the pins, log a diagnostic, and fail so the
+	#    pre-start guard blocks a second daemon.
+	if [ -e /sys/fs/bpf/daed ]; then
+		logger -t daed-init "cleanup: retaining /sys/fs/bpf/daed; pinned eBPF state requires manual recovery or reboot"
+		rc=1
 	fi
 
 	# Final verification. If any of these three still exist the

--- a/daed/files/daed-cleanup.sh
+++ b/daed/files/daed-cleanup.sh
@@ -86,20 +86,49 @@ daed_cleanup_runtime() {
 	#    https://github.com/daeuniverse/dae/issues/1092 for context.
 	if [ -d /sys/fs/bpf/daed ]; then
 		if _bpftool_available; then
+			# Best-effort detach each pinned program. The
+			# `bpftool prog detach pinned <path>` form (no
+			# ATTACH_TYPE) is supported by iproute2's bpftool
+			# 5.x+ and is enough for the cleanup we need; it
+			# detaches from every attach point. The output is
+			# intentionally ignored (it is too verbose to be
+			# useful here).
 			for p in /sys/fs/bpf/daed/*/; do
 				[ -d "$p" ] || continue
-				bpftool prog detach pinned "${p%/}" 2>/dev/null || true
+				if ! bpftool prog detach pinned "${p%/}" >/dev/null 2>&1; then
+					logger -t daed-init "cleanup: bpftool prog detach failed for ${p}; tc filter may still be attached to br-lan"
+					rc=1
+				fi
 			done
 		else
-			logger -t daed-init "cleanup: bpftool not found; cannot detach pinned eBPF programs. Install bpftool-full and re-run, or reboot."
+			# bpftool not installed. We cannot guarantee the
+			# pinned programs are detached, so we MUST NOT rm
+			# the bpffs directory either — that would silently
+			# leave a leaked eBPF program hijacking traffic.
+			# Bail out non-zero so the operator knows they
+			# need to install bpftool-full or reboot.
+			#
+			# This is the path kenzok8 2026.08.21-r1 / 2026.08.28-r4
+			# take by default on stock OpenWrt, and is the
+			# reason the eBPF leak we hit on 2026-09-06 09:37
+			# persisted until the next reboot — see Codex
+			# review on kenzok8/openwrt-daede#70 (P1).
+			logger -t daed-init "cleanup: bpftool not found; cannot detach pinned eBPF programs. Install bpftool-full and re-run, or reboot. Skipping bpffs removal."
+			rc=1
 		fi
 
-		# 5. Remove the bpffs directory itself. Even if bpftool
-		#    detach failed, the kernel will let us rm a directory
-		#    that contains only detached programs.
-		if ! rm -rf /sys/fs/bpf/daed 2>/dev/null; then
-			logger -t daed-init "cleanup: failed to remove /sys/fs/bpf/daed"
-			rc=1
+		# 5. Remove the bpffs directory itself. Only safe when
+		#    every program above detached cleanly (or there were
+		#    none). If detach failed, the pinned programs are
+		#    still attached to br-lan; rm'ing the bpffs does
+		#    NOT un-attach them, and a final-verification check
+		#    that only looks at the filesystem would falsely
+		#    report success.
+		if [ "$rc" -eq 0 ]; then
+			if ! rm -rf /sys/fs/bpf/daed 2>/dev/null; then
+				logger -t daed-init "cleanup: failed to remove /sys/fs/bpf/daed"
+				rc=1
+			fi
 		fi
 	fi
 

--- a/daed/files/daed-cleanup.sh
+++ b/daed/files/daed-cleanup.sh
@@ -60,21 +60,23 @@ daed_cleanup_runtime() {
 	# netns, the veth, or the eBPF dataplane. They are in active
 	# use; removing them would make every connection through dae
 	# hang.
-	if pgrep -f "^/usr/bin/daed " >/dev/null 2>&1; then
-		# Stale-child guard (P1-#6 in the Codex review on
-		# kenzok8/openwrt-daede#70): if we get here from
-		# daed-guard's pre-start cleanup, that means a previous
-		# wrapper run was killed and its /usr/bin/daed child
-		# outlived it. Returning 0 would let daed-guard
-		# proceed to start a SECOND daed against the same
-		# eBPF dataplane, which corrupts the kernel state.
-		# Returning 1 makes the wrapper refuse to start.
-		#
-		# daed-guard distinguishes the two contexts by
-		# checking whether $DAED_GUARD_CLEANUP is "start" or
-		# "post-exit". In the "post-exit" context the child
-		# is gone and this branch is unreachable.
-		[ "${DAED_GUARD_CLEANUP:-start}" = "start" ] && return 1
+	if pgrep -f '^/usr/bin/daed([[:space:]]|$)' >/dev/null 2>&1; then
+		if [ "${DAED_GUARD_CLEANUP:-start}" = "start" ]; then
+			# Stale-child guard (P1-#6 in the Codex review on
+			# kenzok8/openwrt-daede#70): if we get here from
+			# daed-guard's pre-start cleanup, a previous wrapper
+			# was killed and its /usr/bin/daed child outlived it.
+			# Returning 1 makes the wrapper refuse to start a
+			# SECOND daed against the same eBPF dataplane.
+			logger -t daed-init "cleanup: pre-start skipped because /usr/bin/daed is still running; refusing a second instance"
+			return 1
+		fi
+
+		# A different daed instance may still be alive during a
+		# post-exit cleanup (for example, while procd is handling a
+		# stale wrapper). Do not touch its runtime state, but make
+		# the reason visible instead of silently reporting success.
+		logger -t daed-init "cleanup: post-exit skipped because another /usr/bin/daed instance is still running"
 		return 0
 	fi
 

--- a/daed/files/daed-cleanup.sh
+++ b/daed/files/daed-cleanup.sh
@@ -6,8 +6,37 @@
 #   2. The `daens` network namespace itself (ip netns del, with
 #      umount+rm as fallback for zombie nsfs mounts)
 #   3. The `dae0` veth pair in the host netns
-#   4. Pinned eBPF programs and maps under /sys/fs/bpf/daed
-#   5. The /sys/fs/bpf/daed directory itself
+#
+# What this script intentionally does NOT do:
+#
+#   It does NOT try to detach the eBPF tc clsact filter that daed
+#   pins on br-lan / dae0 ingress. The detach path lives inside
+#   the daed userspace process itself (`ControlPlane.DetachBpfHooks`
+#   → `netlink.FilterDel` / `tc qdisc del dev <iface> clsact`,
+#   control/control_plane_core.go:228, control/bpf_purge.go:30-41).
+#   `bpftool prog detach` is the wrong tool: it only handles the
+#   attach types the kernel exposes through bpf_iter / bpf_link
+#   (sk_msg_verdict, sk_skb_verdict, sk_skb_stream_verdict,
+#   sk_skb_stream_parser, flow_dissector), and daed's hooks are
+#   attached via `netlink.FilterAdd` as TC clsact filters, which
+#   are not on that list. kenzok8 confirmed this on PR
+#   kenzok8/openwrt-daede#70 (review, 2026-09-06 12:37Z).
+#
+#   The honest summary of what an opkg-side wrapper can and cannot
+#   do for the eBPF-leak problem (daeuniverse/dae#1092):
+#
+#     CAN do:                                        CANNOT do:
+#     reap daens netns                                detach pinned tc clsact filters
+#     reap dae0 veth pair                             delete /sys/fs/bpf/daed cleanly
+#     refuse to start a second daed (see
+#     daed-guard's pgrep check)
+#
+#   The pinned-tc-clsact fix has to land in daed's own graceful
+#   shutdown path (which is already the case — see
+#   dae/cmd/run.go:1035), or in a separate kernel-level cleanup
+#   helper. The opkg wrapper's job is to make sure the netns/veth
+#   state is clean and to make a stale eBPF situation visible in
+#   logread so an operator knows a reboot is required.
 #
 # Idempotent: re-running on a clean system is a no-op. Safe to call
 # while daed is running — every potentially-destructive step is
@@ -16,7 +45,7 @@
 # Companion to daed-guard: that wrapper calls daed_cleanup_runtime
 # before exec'ing the daemon (so any stale state from a previous
 # crashed run is reaped) and again after the daemon exits (so a
-# OOM-kill or kernel panic also leaves the dataplane clean).
+# OOM-kill or kernel panic also leaves the netns/veth clean).
 #
 # This script is a kenzok8/openwrt-daede-specific evolution of the
 # file originally shipped in daeuniverse/daed's `install/linux/`.
@@ -24,25 +53,28 @@
 # `procd init.d/daed` and the `daed-guard` wrapper can both
 # source it.
 
-_daed_is_running() {
-	pgrep -f "^/usr/bin/daed " >/dev/null 2>&1
-}
-
-_bpftool_available() {
-	command -v bpftool >/dev/null 2>&1
-}
-
 daed_cleanup_runtime() {
-	local pid p rc=0
+	local pid rc=0
 
 	# If daed userspace is currently running, do not touch the
 	# netns, the veth, or the eBPF dataplane. They are in active
 	# use; removing them would make every connection through dae
-	# hang. The wrapper calls us from a child wait context where
-	# the child is already gone, but procd init.d/daed can call us
-	# while the daemon is still alive (e.g. from `restart`), so
-	# the check is necessary.
-	if _daed_is_running; then
+	# hang.
+	if pgrep -f "^/usr/bin/daed " >/dev/null 2>&1; then
+		# Stale-child guard (P1-#6 in the Codex review on
+		# kenzok8/openwrt-daede#70): if we get here from
+		# daed-guard's pre-start cleanup, that means a previous
+		# wrapper run was killed and its /usr/bin/daed child
+		# outlived it. Returning 0 would let daed-guard
+		# proceed to start a SECOND daed against the same
+		# eBPF dataplane, which corrupts the kernel state.
+		# Returning 1 makes the wrapper refuse to start.
+		#
+		# daed-guard distinguishes the two contexts by
+		# checking whether $DAED_GUARD_CLEANUP is "start" or
+		# "post-exit". In the "post-exit" context the child
+		# is gone and this branch is unreachable.
+		[ "${DAED_GUARD_CLEANUP:-start}" = "start" ] && return 1
 		return 0
 	fi
 
@@ -78,66 +110,31 @@ daed_cleanup_runtime() {
 		fi
 	fi
 
-	# 4. Detach and remove pinned eBPF programs. Required because
-	#    daed 0.x closes its own eBPF objects only on a successful
-	#    non-reload Close; on unexpected exits (OOM-kill, kernel
-	#    panic, SIGHUP) the pinned programs stay attached to
-	#    br-lan ingress and keep hijacking traffic. See
-	#    https://github.com/daeuniverse/dae/issues/1092 for context.
+	# 4. /sys/fs/bpf/daed bpffs. The eBPF programs inside are
+	#    owned by the daed userspace process; if daed is not
+	#    running (we already checked above) the pinned
+	#    programs are no longer attached, but the bpffs
+	#    directory may still exist. Removing the directory
+	#    here only unlinks the bpffs inode; it does NOT
+	#    detach a TC clsact filter (see the file header for
+	#    the full explanation). If the eBPF leak we hit on
+	#    2026-09-06 09:37 has happened, the tc clsact filter
+	#    is still attached to br-lan ingress even after this
+	#    rm, and a reboot is the only safe recovery. We do
+	#    best-effort cleanup so an operator's manual `rm
+	#    /sys/fs/bpf/daed` is not required.
 	if [ -d /sys/fs/bpf/daed ]; then
-		if _bpftool_available; then
-			# Best-effort detach each pinned program. The
-			# `bpftool prog detach pinned <path>` form (no
-			# ATTACH_TYPE) is supported by iproute2's bpftool
-			# 5.x+ and is enough for the cleanup we need; it
-			# detaches from every attach point. The output is
-			# intentionally ignored (it is too verbose to be
-			# useful here).
-			for p in /sys/fs/bpf/daed/*/; do
-				[ -d "$p" ] || continue
-				if ! bpftool prog detach pinned "${p%/}" >/dev/null 2>&1; then
-					logger -t daed-init "cleanup: bpftool prog detach failed for ${p}; tc filter may still be attached to br-lan"
-					rc=1
-				fi
-			done
-		else
-			# bpftool not installed. We cannot guarantee the
-			# pinned programs are detached, so we MUST NOT rm
-			# the bpffs directory either — that would silently
-			# leave a leaked eBPF program hijacking traffic.
-			# Bail out non-zero so the operator knows they
-			# need to install bpftool-full or reboot.
-			#
-			# This is the path kenzok8 2026.08.21-r1 / 2026.08.28-r4
-			# take by default on stock OpenWrt, and is the
-			# reason the eBPF leak we hit on 2026-09-06 09:37
-			# persisted until the next reboot — see Codex
-			# review on kenzok8/openwrt-daede#70 (P1).
-			logger -t daed-init "cleanup: bpftool not found; cannot detach pinned eBPF programs. Install bpftool-full and re-run, or reboot. Skipping bpffs removal."
-			rc=1
-		fi
-
-		# 5. Remove the bpffs directory itself. Only safe when
-		#    every program above detached cleanly (or there were
-		#    none). If detach failed, the pinned programs are
-		#    still attached to br-lan; rm'ing the bpffs does
-		#    NOT un-attach them, and a final-verification check
-		#    that only looks at the filesystem would falsely
-		#    report success.
-		if [ "$rc" -eq 0 ]; then
-			if ! rm -rf /sys/fs/bpf/daed 2>/dev/null; then
-				logger -t daed-init "cleanup: failed to remove /sys/fs/bpf/daed"
-				rc=1
-			fi
+		if ! rm -rf /sys/fs/bpf/daed 2>/dev/null; then
+			logger -t daed-init "cleanup: /sys/fs/bpf/daed still present after rm; this is harmless but indicates the eBPF leak path. Reboot if traffic is hijacked."
 		fi
 	fi
 
-	# Final verification. If any of these four still exist the
+	# Final verification. If any of these three still exist the
 	# caller will see a non-zero exit and can decide to reboot.
+	# (We do NOT check /sys/fs/bpf/daed here — see file header.)
 	[ ! -e /run/netns/daens ] || return 1
 	! ip netns list 2>/dev/null | awk '$1 == "daens" { found=1 } END { exit !found }' || return 1
 	! ip link show dae0 >/dev/null 2>&1 || return 1
-	[ ! -e /sys/fs/bpf/daed ] || return 1
 
 	return $rc
 }

--- a/daed/files/daed-cleanup.sh
+++ b/daed/files/daed-cleanup.sh
@@ -1,8 +1,52 @@
 #!/bin/sh
+# daed-cleanup.sh — reaper for stale daed kernel state.
+#
+# Removes:
+#   1. Processes inside the `daens` netns (SIGTERM, then SIGKILL after 1s)
+#   2. The `daens` network namespace itself (ip netns del, with
+#      umount+rm as fallback for zombie nsfs mounts)
+#   3. The `dae0` veth pair in the host netns
+#   4. Pinned eBPF programs and maps under /sys/fs/bpf/daed
+#   5. The /sys/fs/bpf/daed directory itself
+#
+# Idempotent: re-running on a clean system is a no-op. Safe to call
+# while daed is running — every potentially-destructive step is
+# guarded by a `pgrep -f /usr/bin/daed` check.
+#
+# Companion to daed-guard: that wrapper calls daed_cleanup_runtime
+# before exec'ing the daemon (so any stale state from a previous
+# crashed run is reaped) and again after the daemon exits (so a
+# OOM-kill or kernel panic also leaves the dataplane clean).
+#
+# This script is a kenzok8/openwrt-daede-specific evolution of the
+# file originally shipped in daeuniverse/daed's `install/linux/`.
+# It must remain a single function (`daed_cleanup_runtime`) so the
+# `procd init.d/daed` and the `daed-guard` wrapper can both
+# source it.
+
+_daed_is_running() {
+	pgrep -f "^/usr/bin/daed " >/dev/null 2>&1
+}
+
+_bpftool_available() {
+	command -v bpftool >/dev/null 2>&1
+}
 
 daed_cleanup_runtime() {
-	local pid
+	local pid p rc=0
 
+	# If daed userspace is currently running, do not touch the
+	# netns, the veth, or the eBPF dataplane. They are in active
+	# use; removing them would make every connection through dae
+	# hang. The wrapper calls us from a child wait context where
+	# the child is already gone, but procd init.d/daed can call us
+	# while the daemon is still alive (e.g. from `restart`), so
+	# the check is necessary.
+	if _daed_is_running; then
+		return 0
+	fi
+
+	# 1. Kill processes inside daens.
 	for pid in $(ip netns pids daens 2>/dev/null); do
 		kill "$pid" 2>/dev/null
 	done
@@ -14,14 +58,57 @@ daed_cleanup_runtime() {
 		done
 	fi
 
+	# 2. Remove the daens netns. ip netns del can fail if a
+	#    process still references it via /proc/<pid>/ns/net or
+	#    because the umount has already happened. Try the
+	#    umount/rm fallback.
 	if ! ip netns del daens 2>/dev/null; then
 		umount -l /run/netns/daens 2>/dev/null
-		rm -f /run/netns/daens
+		if [ -e /run/netns/daens ] && ! rm -f /run/netns/daens 2>/dev/null; then
+			logger -t daed-init "cleanup: failed to remove /run/netns/daens (resource busy); a reboot may be required"
+			rc=1
+		fi
 	fi
 
-	ip link del dae0 2>/dev/null || true
+	# 3. Remove the dae0 veth pair.
+	if ip link show dae0 >/dev/null 2>&1; then
+		if ! ip link del dae0 2>/dev/null; then
+			logger -t daed-init "cleanup: failed to remove dae0 veth pair"
+			rc=1
+		fi
+	fi
 
+	# 4. Detach and remove pinned eBPF programs. Required because
+	#    daed 0.x closes its own eBPF objects only on a successful
+	#    non-reload Close; on unexpected exits (OOM-kill, kernel
+	#    panic, SIGHUP) the pinned programs stay attached to
+	#    br-lan ingress and keep hijacking traffic. See
+	#    https://github.com/daeuniverse/dae/issues/1092 for context.
+	if [ -d /sys/fs/bpf/daed ]; then
+		if _bpftool_available; then
+			for p in /sys/fs/bpf/daed/*/; do
+				[ -d "$p" ] || continue
+				bpftool prog detach pinned "${p%/}" 2>/dev/null || true
+			done
+		else
+			logger -t daed-init "cleanup: bpftool not found; cannot detach pinned eBPF programs. Install bpftool-full and re-run, or reboot."
+		fi
+
+		# 5. Remove the bpffs directory itself. Even if bpftool
+		#    detach failed, the kernel will let us rm a directory
+		#    that contains only detached programs.
+		if ! rm -rf /sys/fs/bpf/daed 2>/dev/null; then
+			logger -t daed-init "cleanup: failed to remove /sys/fs/bpf/daed"
+			rc=1
+		fi
+	fi
+
+	# Final verification. If any of these four still exist the
+	# caller will see a non-zero exit and can decide to reboot.
 	[ ! -e /run/netns/daens ] || return 1
 	! ip netns list 2>/dev/null | awk '$1 == "daens" { found=1 } END { exit !found }' || return 1
 	! ip link show dae0 >/dev/null 2>&1 || return 1
+	[ ! -e /sys/fs/bpf/daed ] || return 1
+
+	return $rc
 }

--- a/daed/files/daed-guard
+++ b/daed/files/daed-guard
@@ -3,12 +3,8 @@
 # kernel state (network namespace, veth pair) is reaped before the
 # daemon starts AND after it exits.
 #
-# What this wrapper does NOT do (see daed-cleanup.sh for the full
-# explanation): detach the pinned eBPF tc clsact filter that daed
-# attaches to br-lan / dae0 ingress. That lives inside the daed
-# userspace process itself; the opkg-side wrapper can only
-# reap netns and veth. If daed is OOM-killed or panics, the
-# filter survives and only a reboot clears it.
+# The wrapper only reaps stale netns/veth state. daed itself owns
+# TC clsact detach; /sys/fs/bpf/daed is normal persistent pin state.
 #
 # Two cleanup passes:
 #   - before exec: a stale run may have left daens / dae0 from an
@@ -30,53 +26,35 @@
 
 . /usr/share/daed/cleanup.sh
 
-# Pre-start cleanup context. cleanup.sh uses this to refuse to
-# start a second daed if a previous /usr/bin/daed orphan is
-# still running (P1-#6 in the Codex review on
-# kenzok8/openwrt-daede#70).
+# Pre-start cleanup refuses to remove runtime state while another
+# daed instance is active, and fails closed if that probe is broken.
 DAED_GUARD_CLEANUP=start
-if [ -e /sys/fs/bpf/daed ]; then
-	echo "daed: /sys/fs/bpf/daed is still present; refusing to start. Retain the pins and reboot or clear kernel state manually." >&2
-	logger -t daed-init "pre-start blocked: /sys/fs/bpf/daed exists; retaining pins"
-	exit 1
-fi
 if ! daed_cleanup_runtime; then
-	# A previous daed-guard run was killed and its /usr/bin/daed
-	# child outlived it, OR the daens netns is busy. Refuse to
-	# start a second daed — that would corrupt the eBPF
-	# dataplane. Operator must kill the orphan or reboot.
-	echo "daed: stale /usr/bin/daed or netns/bpf state could not be removed; refusing to start. Check 'pgrep -af /usr/bin/daed' and 'ip netns list'." >&2
-	logger -t daed-init "pre-start cleanup failed: refusing to start daed to avoid a second instance. Check ip netns list and pgrep -af /usr/bin/daed."
+	echo "daed: stale /usr/bin/daed or netns state could not be verified or removed; refusing to start. Check process and netns state." >&2
+	logger -t daed-init "pre-start cleanup failed: refusing to start daed"
 	exit 1
 fi
 
-if [ -e /sys/fs/bpf/daed ]; then
-	echo "daed: /sys/fs/bpf/daed appeared during pre-start cleanup; refusing to start." >&2
-	logger -t daed-init "pre-start blocked: /sys/fs/bpf/daed appeared; retaining pins"
-	exit 1
-fi
-
-# 2. Keep daed as a child so a panic or unexpected exit is followed
-#    by an immediate teardown of all kernel/runtime state before
-#    procd can respawn us.
+# Keep daed as a child so post-exit cleanup runs before procd can
+# respawn it.
 child_pid=
 pending_signal=
 
 forward_signal() {
-	# Forward the same signal that hit the wrapper, not a bare
-	# kill (defaults to TERM). HUP/QUIT must stay HUP/QUIT so
-	# dae's graceful path sees the original intent. kenzok8
-	# review on kenzok8/openwrt-daede#70.
 	_sig="$1"
 	if [ -z "$child_pid" ]; then
-		# The trap is installed before start_child. Remember a stop
-		# signal received in that window so the daemon is never
-		# launched after the wrapper has already been asked to stop.
 		pending_signal="$_sig"
 		logger -t daed-init "signal $_sig received before daed child started; launch cancelled"
 		return 0
 	fi
 	[ -n "$_sig" ] && kill -"$_sig" "$child_pid" 2>/dev/null
+}
+
+exit_with_signal() {
+	_sig="$1"
+	trap - TERM INT HUP QUIT
+	kill -"$_sig" "$$" 2>/dev/null
+	exit 1
 }
 trap 'forward_signal TERM' TERM
 trap 'forward_signal INT' INT
@@ -99,36 +77,18 @@ start_child() {
 
 if [ -n "$pending_signal" ]; then
 	logger -t daed-init "refusing to start daed after pending signal $pending_signal"
-	trap - TERM INT HUP QUIT
-	exit 1
+	exit_with_signal "$pending_signal"
 fi
 
-# Run the daemon. POSIX `wait` returns immediately when the
-# wrapper itself receives a signal (TERM/INT/HUP/QUIT), so a
-# single `wait "$child_pid"` would race: the trap fires and
-# forwards the signal, but `wait` returns with a signal-derived
-# status before the child has actually finished its graceful
-# shutdown. The wrapper would then run cleanup (which is a no-op
-# because the child is still running), exit, and procd would
-# spawn a SECOND daed while the first is still alive — two
-# daeds fighting over the same eBPF dataplane.
-#
-# Poll until the child is gone. Each wait may return early on
-# signal; save its status. When wait actually reaps the child,
-# kill -0 fails and we break with that real exit code. Do NOT
-# issue an unconditional post-loop wait: ash then reports
-# "not a child" and status becomes 127. kenzok8 review on
-# kenzok8/openwrt-daede#70.
-#
-# Best-effort OOM score before fork: procd_set_param has no
-# oom_adj case, so write /proc/self/oom_score_adj here; the
-# child inherits it. Failure must not block start.
+# Best-effort OOM preference; failure must not block startup.
 if ! echo -16 > /proc/self/oom_score_adj 2>/dev/null; then
 	logger -t daed-init "warn: failed to set /proc/self/oom_score_adj; continuing without OOM preference"
 fi
 if ! start_child "$@"; then
 	logger -t daed-init "refusing to start daed after pending signal $pending_signal"
-	trap - TERM INT HUP QUIT
+	if [ -n "$pending_signal" ]; then
+		exit_with_signal "$pending_signal"
+	fi
 	exit 1
 fi
 status=0
@@ -136,8 +96,6 @@ reaped=0
 while [ "$reaped" -eq 0 ]; do
 	wait "$child_pid" 2>/dev/null
 	status=$?
-	# A failed kill -0 means wait reaped the child. Never wait
-	# again after that point; ash reports 127 for a reaped child.
 	if ! kill -0 "$child_pid" 2>/dev/null; then
 		reaped=1
 	fi
@@ -145,10 +103,7 @@ done
 child_pid=
 trap - TERM INT HUP QUIT
 
-# 3. Post-exit cleanup. Switch to "post-exit" context so the
-#    pgrep check inside cleanup.sh does NOT refuse to run
-#    (the child is gone, but a real cleanup pass is still
-#    wanted in case the child's exit left stale netns/veth).
+# Post-exit cleanup runs after the child is reaped.
 DAED_GUARD_CLEANUP=post-exit
 cleanup_status=0
 daed_cleanup_runtime || cleanup_status=$?

--- a/daed/files/daed-guard
+++ b/daed/files/daed-guard
@@ -60,6 +60,7 @@ fi
 #    by an immediate teardown of all kernel/runtime state before
 #    procd can respawn us.
 child_pid=
+pending_signal=
 
 forward_signal() {
 	# Forward the same signal that hit the wrapper, not a bare
@@ -67,7 +68,15 @@ forward_signal() {
 	# dae's graceful path sees the original intent. kenzok8
 	# review on kenzok8/openwrt-daede#70.
 	_sig="$1"
-	[ -n "$child_pid" ] && [ -n "$_sig" ] && kill -"$_sig" "$child_pid" 2>/dev/null
+	if [ -z "$child_pid" ]; then
+		# The trap is installed before start_child. Remember a stop
+		# signal received in that window so the daemon is never
+		# launched after the wrapper has already been asked to stop.
+		pending_signal="$_sig"
+		logger -t daed-init "signal $_sig received before daed child started; launch cancelled"
+		return 0
+	fi
+	[ -n "$_sig" ] && kill -"$_sig" "$child_pid" 2>/dev/null
 }
 trap 'forward_signal TERM' TERM
 trap 'forward_signal INT' INT
@@ -75,9 +84,24 @@ trap 'forward_signal HUP' HUP
 trap 'forward_signal QUIT' QUIT
 
 start_child() {
+	# Keep this check inside the function as well as at the call site:
+	# it closes the ordinary pre-start window, while the pending-signal
+	# path below handles a signal arriving during the background fork.
+	[ -z "$pending_signal" ] || return 125
 	/usr/bin/daed "$@" &
 	child_pid=$!
+	if [ -n "$pending_signal" ]; then
+		_sig="$pending_signal"
+		pending_signal=
+		forward_signal "$_sig"
+	fi
 }
+
+if [ -n "$pending_signal" ]; then
+	logger -t daed-init "refusing to start daed after pending signal $pending_signal"
+	trap - TERM INT HUP QUIT
+	exit 1
+fi
 
 # Run the daemon. POSIX `wait` returns immediately when the
 # wrapper itself receives a signal (TERM/INT/HUP/QUIT), so a
@@ -102,7 +126,11 @@ start_child() {
 if ! echo -16 > /proc/self/oom_score_adj 2>/dev/null; then
 	logger -t daed-init "warn: failed to set /proc/self/oom_score_adj; continuing without OOM preference"
 fi
-start_child "$@"
+if ! start_child "$@"; then
+	logger -t daed-init "refusing to start daed after pending signal $pending_signal"
+	trap - TERM INT HUP QUIT
+	exit 1
+fi
 status=0
 reaped=0
 while [ "$reaped" -eq 0 ]; do

--- a/daed/files/daed-guard
+++ b/daed/files/daed-guard
@@ -1,11 +1,18 @@
 #!/bin/sh
 # daed-guard — thin wrapper around /usr/bin/daed that ensures stale
-# kernel state (network namespace, veth pair, pinned eBPF programs)
-# is reaped before the daemon starts AND after it exits.
+# kernel state (network namespace, veth pair) is reaped before the
+# daemon starts AND after it exits.
+#
+# What this wrapper does NOT do (see daed-cleanup.sh for the full
+# explanation): detach the pinned eBPF tc clsact filter that daed
+# attaches to br-lan / dae0 ingress. That lives inside the daed
+# userspace process itself; the opkg-side wrapper can only
+# reap netns and veth. If daed is OOM-killed or panics, the
+# filter survives and only a reboot clears it.
 #
 # Two cleanup passes:
-#   - before exec: a stale run may have left daens / dae0 / bpf
-#     pinned from an OOM-kill or kernel panic. We reap first.
+#   - before exec: a stale run may have left daens / dae0 from an
+#     OOM-kill or kernel panic. We reap first.
 #   - after exit: a normal exit (including signal-induced ones)
 #     also reaps, so a partial state never survives.
 #
@@ -23,11 +30,18 @@
 
 . /usr/share/daed/cleanup.sh
 
-# 1. Stale-state cleanup before the daemon starts. If anything
-#    fails we abort early so the operator sees the error in
-#    logread.
+# Pre-start cleanup context. cleanup.sh uses this to refuse to
+# start a second daed if a previous /usr/bin/daed orphan is
+# still running (P1-#6 in the Codex review on
+# kenzok8/openwrt-daede#70).
+DAED_GUARD_CLEANUP=start
 if ! daed_cleanup_runtime; then
-	echo "daed: stale network state could not be removed" >&2
+	# A previous daed-guard run was killed and its /usr/bin/daed
+	# child outlived it, OR the daens netns is busy. Refuse to
+	# start a second daed — that would corrupt the eBPF
+	# dataplane. Operator must kill the orphan or reboot.
+	echo "daed: stale /usr/bin/daed or netns/bpf state could not be removed; refusing to start. Check 'pgrep -af /usr/bin/daed' and 'ip netns list'." >&2
+	logger -t daed-init "pre-start cleanup failed: refusing to start daed to avoid a second instance. Check ip netns list and pgrep -af /usr/bin/daed."
 	exit 1
 fi
 
@@ -78,13 +92,14 @@ status=$?
 child_pid=
 trap - TERM INT HUP QUIT
 
-# 3. Post-exit cleanup. If this fails we override the child's exit
-#    code to 1 so procd notices; an operator looking at the log
-#    will see both the kernel-state error and the original exit
-#    reason from dae.
+# 3. Post-exit cleanup. Switch to "post-exit" context so the
+#    pgrep check inside cleanup.sh does NOT refuse to run
+#    (the child is gone, but a real cleanup pass is still
+#    wanted in case the child's exit left stale netns/veth).
+DAED_GUARD_CLEANUP=post-exit
 if ! daed_cleanup_runtime; then
 	echo "daed: runtime cleanup after exit failed" >&2
-	logger -t daed-init "post-exit cleanup failed; check ip netns / bpf prog state"
+	logger -t daed-init "post-exit cleanup failed; check ip netns / ip link show"
 	status=1
 fi
 exit "$status"

--- a/daed/files/daed-guard
+++ b/daed/files/daed-guard
@@ -1,29 +1,69 @@
 #!/bin/sh
+# daed-guard — thin wrapper around /usr/bin/daed that ensures stale
+# kernel state (network namespace, veth pair, pinned eBPF programs)
+# is reaped before the daemon starts AND after it exits.
+#
+# Two cleanup passes:
+#   - before exec: a stale run may have left daens / dae0 / bpf
+#     pinned from an OOM-kill or kernel panic. We reap first.
+#   - after exit: a normal exit (including signal-induced ones)
+#     also reaps, so a partial state never survives.
+#
+# Signal handling:
+#   - TERM / INT / HUP / QUIT forwarded to the child so dae can
+#     run its own graceful shutdown (DetachBpfHooks + Close).
+#   - exit trap runs the post-exit cleanup unconditionally.
+#
+# This wrapper preserves the kenzok8/openwrt-daede convention of
+# backgrounding the child with `&` and `wait`ing on it, so the
+# wrapper itself stays around to do the post-exit cleanup. That
+# is more robust than the daeuniverse/daed reference (which uses
+# `exec`) because it lets us distinguish "child exited cleanly"
+# from "wrapper itself was signalled".
 
 . /usr/share/daed/cleanup.sh
 
+# 1. Stale-state cleanup before the daemon starts. If anything
+#    fails we abort early so the operator sees the error in
+#    logread.
 if ! daed_cleanup_runtime; then
 	echo "daed: stale network state could not be removed" >&2
 	exit 1
 fi
 
-# Keep daed as a child so a panic or unexpected exit is followed by an
-# immediate teardown of all kernel/runtime state before procd can respawn us.
+# 2. Keep daed as a child so a panic or unexpected exit is followed
+#    by an immediate teardown of all kernel/runtime state before
+#    procd can respawn us.
 child_pid=
-cleanup_child() {
+
+forward_signal() {
+	# Forward every terminating signal we receive to the child,
+	# so dae gets a chance to run its own graceful shutdown.
+	# EXIT is handled separately below.
 	[ -n "$child_pid" ] && kill "$child_pid" 2>/dev/null
 }
-trap cleanup_child TERM INT
+trap forward_signal TERM INT HUP QUIT
 
-/usr/bin/daed "$@" &
-child_pid=$!
+start_child() {
+	/usr/bin/daed "$@" &
+	child_pid=$!
+}
+
+# Run the daemon. wait returns the child's exit code; preserve it
+# as the wrapper's exit so procd sees the right respawn counter.
+start_child "$@"
 wait "$child_pid"
 status=$?
 child_pid=
-trap - TERM INT
+trap - TERM INT HUP QUIT
 
+# 3. Post-exit cleanup. If this fails we override the child's exit
+#    code to 1 so procd notices; an operator looking at the log
+#    will see both the kernel-state error and the original exit
+#    reason from dae.
 if ! daed_cleanup_runtime; then
 	echo "daed: runtime cleanup after exit failed" >&2
+	logger -t daed-init "post-exit cleanup failed; check ip netns / bpf prog state"
 	status=1
 fi
 exit "$status"

--- a/daed/files/daed-guard
+++ b/daed/files/daed-guard
@@ -49,9 +49,30 @@ start_child() {
 	child_pid=$!
 }
 
-# Run the daemon. wait returns the child's exit code; preserve it
-# as the wrapper's exit so procd sees the right respawn counter.
+# Run the daemon. POSIX `wait` returns immediately when the
+# wrapper itself receives a signal (TERM/INT/HUP/QUIT), so a
+# single `wait "$child_pid"` would race: the trap fires and
+# forwards the signal, but `wait` returns with a signal-derived
+# status before the child has actually finished its graceful
+# shutdown. The wrapper would then run cleanup (which is a no-op
+# because the child is still running), exit, and procd would
+# spawn a SECOND daed while the first is still alive — two
+# daeds fighting over the same eBPF dataplane.
+#
+# To prevent that, use a polling loop: every time `wait` returns
+# because of a signal, the trap has already fired and the child
+# has been signalled. We loop and `wait` again until `kill -0`
+# confirms the child is actually gone. Then a final `wait` reaps
+# the child and gives us its real exit status.
+#
+# See Codex review on kenzok8/openwrt-daede#70 (P1) for the
+# bug-trigger trace.
 start_child "$@"
+while kill -0 "$child_pid" 2>/dev/null; do
+	wait "$child_pid" 2>/dev/null
+	# wait returned because of a signal; the trap fired and
+	# forwarded the signal to the child. Loop and wait again.
+done
 wait "$child_pid"
 status=$?
 child_pid=

--- a/daed/files/daed-guard
+++ b/daed/files/daed-guard
@@ -35,6 +35,11 @@
 # still running (P1-#6 in the Codex review on
 # kenzok8/openwrt-daede#70).
 DAED_GUARD_CLEANUP=start
+if [ -e /sys/fs/bpf/daed ]; then
+	echo "daed: /sys/fs/bpf/daed is still present; refusing to start. Retain the pins and reboot or clear kernel state manually." >&2
+	logger -t daed-init "pre-start blocked: /sys/fs/bpf/daed exists; retaining pins"
+	exit 1
+fi
 if ! daed_cleanup_runtime; then
 	# A previous daed-guard run was killed and its /usr/bin/daed
 	# child outlived it, OR the daens netns is busy. Refuse to
@@ -45,18 +50,29 @@ if ! daed_cleanup_runtime; then
 	exit 1
 fi
 
+if [ -e /sys/fs/bpf/daed ]; then
+	echo "daed: /sys/fs/bpf/daed appeared during pre-start cleanup; refusing to start." >&2
+	logger -t daed-init "pre-start blocked: /sys/fs/bpf/daed appeared; retaining pins"
+	exit 1
+fi
+
 # 2. Keep daed as a child so a panic or unexpected exit is followed
 #    by an immediate teardown of all kernel/runtime state before
 #    procd can respawn us.
 child_pid=
 
 forward_signal() {
-	# Forward every terminating signal we receive to the child,
-	# so dae gets a chance to run its own graceful shutdown.
-	# EXIT is handled separately below.
-	[ -n "$child_pid" ] && kill "$child_pid" 2>/dev/null
+	# Forward the same signal that hit the wrapper, not a bare
+	# kill (defaults to TERM). HUP/QUIT must stay HUP/QUIT so
+	# dae's graceful path sees the original intent. kenzok8
+	# review on kenzok8/openwrt-daede#70.
+	_sig="$1"
+	[ -n "$child_pid" ] && [ -n "$_sig" ] && kill -"$_sig" "$child_pid" 2>/dev/null
 }
-trap forward_signal TERM INT HUP QUIT
+trap 'forward_signal TERM' TERM
+trap 'forward_signal INT' INT
+trap 'forward_signal HUP' HUP
+trap 'forward_signal QUIT' QUIT
 
 start_child() {
 	/usr/bin/daed "$@" &
@@ -73,22 +89,31 @@ start_child() {
 # spawn a SECOND daed while the first is still alive — two
 # daeds fighting over the same eBPF dataplane.
 #
-# To prevent that, use a polling loop: every time `wait` returns
-# because of a signal, the trap has already fired and the child
-# has been signalled. We loop and `wait` again until `kill -0`
-# confirms the child is actually gone. Then a final `wait` reaps
-# the child and gives us its real exit status.
+# Poll until the child is gone. Each wait may return early on
+# signal; save its status. When wait actually reaps the child,
+# kill -0 fails and we break with that real exit code. Do NOT
+# issue an unconditional post-loop wait: ash then reports
+# "not a child" and status becomes 127. kenzok8 review on
+# kenzok8/openwrt-daede#70.
 #
-# See Codex review on kenzok8/openwrt-daede#70 (P1) for the
-# bug-trigger trace.
+# Best-effort OOM score before fork: procd_set_param has no
+# oom_adj case, so write /proc/self/oom_score_adj here; the
+# child inherits it. Failure must not block start.
+if ! echo -16 > /proc/self/oom_score_adj 2>/dev/null; then
+	logger -t daed-init "warn: failed to set /proc/self/oom_score_adj; continuing without OOM preference"
+fi
 start_child "$@"
-while kill -0 "$child_pid" 2>/dev/null; do
+status=0
+reaped=0
+while [ "$reaped" -eq 0 ]; do
 	wait "$child_pid" 2>/dev/null
-	# wait returned because of a signal; the trap fired and
-	# forwarded the signal to the child. Loop and wait again.
+	status=$?
+	# A failed kill -0 means wait reaped the child. Never wait
+	# again after that point; ash reports 127 for a reaped child.
+	if ! kill -0 "$child_pid" 2>/dev/null; then
+		reaped=1
+	fi
 done
-wait "$child_pid"
-status=$?
 child_pid=
 trap - TERM INT HUP QUIT
 
@@ -97,9 +122,13 @@ trap - TERM INT HUP QUIT
 #    (the child is gone, but a real cleanup pass is still
 #    wanted in case the child's exit left stale netns/veth).
 DAED_GUARD_CLEANUP=post-exit
-if ! daed_cleanup_runtime; then
+cleanup_status=0
+daed_cleanup_runtime || cleanup_status=$?
+if [ "$cleanup_status" -ne 0 ]; then
 	echo "daed: runtime cleanup after exit failed" >&2
 	logger -t daed-init "post-exit cleanup failed; check ip netns / ip link show"
-	status=1
 fi
-exit "$status"
+if [ "$status" -ne 0 ]; then
+	exit "$status"
+fi
+exit "$cleanup_status"

--- a/daed/files/daed.init
+++ b/daed/files/daed.init
@@ -5,11 +5,12 @@
 #   - log every branch via `logger -t daed-init` so silent procd
 #     failures (OOM-kill, kernel panic, abort-before-logger-init)
 #     leave a trail
-#   - bump respawn budget (3600 10 5) so a flapping validate step
-#     does not push daed into the "enabled/stopped" state within a
-#     single day
-#   - request procd_set_param oom_adj=-16 so the kernel OOM-killer
-#     prefers sibling processes over daed
+#   - bump respawn budget (3600 5 10 = threshold/timeout/retry, see
+#     comment in start_service) so a flapping validate step does not
+#     push daed into the "enabled/stopped" state within a single day
+#   - request `procd_set_param oom_adj -16` (note the space — two
+#     arguments) so the kernel OOM-killer prefers sibling processes
+#     over daed
 #   - stop_service() now reports the state of /sys/fs/bpf/daed and
 #     `ip netns list` so an operator can immediately see whether
 #     the dataplane was left attached (and needs a reboot) after
@@ -59,13 +60,25 @@ start_service() {
 
 	procd_set_param limits core="unlimited"
 	procd_set_param limits nofile="1000000 1000000"
-	# 10 attempts per hour is high enough to ride out a flapping
+	# procd_set_param respawn: arguments are (threshold, timeout, retry).
+	#   threshold = seconds in which to count retries (3600 = 1 hour)
+	#   timeout   = seconds to wait between retries
+	#   retry     = maximum number of restart attempts before procd
+	#               gives up and leaves the service in
+	#               "enabled/stopped".
+	# 10 retries per hour is high enough to ride out a flapping
 	# validate step, low enough that a permanently broken config
 	# still surfaces. (Upstream default is 5 — too low once we
 	# add a 5 s tail cleanup in a reload storm.)
-	procd_set_param respawn 3600 10 5
+	procd_set_param respawn 3600 5 10
 	# Tell the kernel OOM-killer to prefer other processes over daed.
-	procd_set_param oom_adj=-16
+	# IMPORTANT: procd_set_param takes TWO arguments here (the
+	# parameter name and its value), not one. Passing
+	# `procd_set_param oom_adj=-16` (one argument) makes procd see
+	# the entire string as an unknown parameter name and silently
+	# drop the directive. See Codex review on
+	# kenzok8/openwrt-daede#70.
+	procd_set_param oom_adj -16
 	# procd_set_param stdout 1
 	procd_set_param stderr 1
 

--- a/daed/files/daed.init
+++ b/daed/files/daed.init
@@ -1,5 +1,21 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2023 Tianling Shen <cnsztl@immortalwrt.org>
+#
+# Improvements in this revision:
+#   - log every branch via `logger -t daed-init` so silent procd
+#     failures (OOM-kill, kernel panic, abort-before-logger-init)
+#     leave a trail
+#   - bump respawn budget (3600 10 5) so a flapping validate step
+#     does not push daed into the "enabled/stopped" state within a
+#     single day
+#   - request procd_set_param oom_adj=-16 so the kernel OOM-killer
+#     prefers sibling processes over daed
+#   - stop_service() now reports the state of /sys/fs/bpf/daed and
+#     `ip netns list` so an operator can immediately see whether
+#     the dataplane was left attached (and needs a reboot) after
+#     a manual stop
+#   - drop the `rm -f "$LOG"` in stop_service so post-mortem logs
+#     survive a manual stop
 
 USE_PROCD=1
 START=99
@@ -10,17 +26,27 @@ LOG="/var/log/daed/daed.log"
 
 . /usr/share/daed/cleanup.sh
 
+log() {
+	logger -t daed-init "$@"
+}
+
 start_service() {
+	log "start: begin"
 	config_load "$CONF"
 
 	local enabled
 	config_get_bool enabled "config" "enabled" "0"
-	[ "$enabled" -eq "1" ] || return 1
+	if [ "$enabled" -ne "1" ]; then
+		log "start: config disabled, exit"
+		return 1
+	fi
 
 	local listen_addr log_maxbackups log_maxsize
 	config_get listen_addr "config" "listen_addr" "0.0.0.0:2023"
 	config_get log_maxbackups "config" "log_maxbackups" "1"
 	config_get log_maxsize "config" "log_maxsize" "5"
+
+	log "start: listen=$listen_addr log_maxbackups=$log_maxbackups log_maxsize=$log_maxsize"
 
 	procd_open_instance "$CONF"
 	procd_set_param env DAE_LOCATION_ASSET="/usr/share/v2ray" TZ="$(uci -q get system.@system[0].zonename)"
@@ -33,24 +59,53 @@ start_service() {
 
 	procd_set_param limits core="unlimited"
 	procd_set_param limits nofile="1000000 1000000"
-	# Avoid an endless crash/respawn loop which can repeatedly reattach dae's
-	# data-plane hooks and make the router management plane unreachable.
-	procd_set_param respawn 3600 5 5
+	# 10 attempts per hour is high enough to ride out a flapping
+	# validate step, low enough that a permanently broken config
+	# still surfaces. (Upstream default is 5 — too low once we
+	# add a 5 s tail cleanup in a reload storm.)
+	procd_set_param respawn 3600 10 5
+	# Tell the kernel OOM-killer to prefer other processes over daed.
+	procd_set_param oom_adj=-16
 	# procd_set_param stdout 1
 	procd_set_param stderr 1
 
 	procd_close_instance
+	log "start: procd_open_instance done"
 }
 
 stop_service() {
-	rm -f "$LOG"
+	log "stop: begin"
+	# Report dataplane state so an operator can see if a reboot
+	# is needed before next start.
+	local pinned="" ns_left=""
+	if [ -d /sys/fs/bpf/daed ]; then
+		pinned=$(ls /sys/fs/bpf/daed 2>/dev/null | tr '\n' ' ')
+	fi
+	if ip netns list 2>/dev/null | grep -q '^daens'; then
+		ns_left="daens"
+	fi
+	log "stop: pre-cleanup state — bpf_pinned=[${pinned:-none}] netns_left=[${ns_left:-none}]"
+
 	daed_cleanup_runtime
+
+	pinned=""
+	ns_left=""
+	if [ -d /sys/fs/bpf/daed ]; then
+		pinned=$(ls /sys/fs/bpf/daed 2>/dev/null | tr '\n' ' ')
+	fi
+	if ip netns list 2>/dev/null | grep -q '^daens'; then
+		ns_left="daens"
+	fi
+	log "stop: post-cleanup state — bpf_pinned=[${pinned:-none}] netns_left=[${ns_left:-none}]"
 }
 
 restart() {
+	log "restart: stop"
 	stop
 	sleep 1
+	log "restart: cleanup"
 	daed_cleanup_runtime
+	log "restart: start"
 	start
 }
 

--- a/daed/files/daed.init
+++ b/daed/files/daed.init
@@ -61,6 +61,8 @@ start_service() {
 
 	procd_set_param limits core="unlimited"
 	procd_set_param limits nofile="1000000 1000000"
+	# Give daed time to detach hooks and let daed-guard reap its child.
+	procd_set_param term_timeout 20
 	# procd_set_param respawn: arguments are (threshold, timeout, retry).
 	#   threshold = seconds in which to count retries (3600 = 1 hour)
 	#   timeout   = seconds to wait between retries

--- a/daed/files/daed.init
+++ b/daed/files/daed.init
@@ -8,9 +8,10 @@
 #   - bump respawn budget (3600 5 10 = threshold/timeout/retry, see
 #     comment in start_service) so a flapping validate step does not
 #     push daed into the "enabled/stopped" state within a single day
-#   - request `procd_set_param oom_adj -16` (note the space — two
-#     arguments) so the kernel OOM-killer prefers sibling processes
-#     over daed
+#   - best-effort OOM preference is applied in daed-guard via
+#     /proc/self/oom_score_adj (procd has no oom_adj case — see
+#     start_service comment and daed-guard); do not use
+#     procd_set_param oom_adj here
 #   - stop_service() now reports the state of /sys/fs/bpf/daed and
 #     `ip netns list` so an operator can immediately see whether
 #     the dataplane was left attached (and needs a reboot) after
@@ -71,14 +72,12 @@ start_service() {
 	# still surfaces. (Upstream default is 5 — too low once we
 	# add a 5 s tail cleanup in a reload storm.)
 	procd_set_param respawn 3600 5 10
-	# Tell the kernel OOM-killer to prefer other processes over daed.
-	# IMPORTANT: procd_set_param takes TWO arguments here (the
-	# parameter name and its value), not one. Passing
-	# `procd_set_param oom_adj=-16` (one argument) makes procd see
-	# the entire string as an unknown parameter name and silently
-	# drop the directive. See Codex review on
+	# OOM preference is intentionally NOT set via procd_set_param.
+	# procd.sh has no oom_adj / oom_score_adj case; such a call is
+	# silently dropped and never reaches the kernel. daed-guard
+	# writes /proc/self/oom_score_adj before forking daed so the
+	# child inherits the score. See kenzok8 review on
 	# kenzok8/openwrt-daede#70.
-	procd_set_param oom_adj -16
 	# procd_set_param stdout 1
 	procd_set_param stderr 1
 
@@ -88,8 +87,13 @@ start_service() {
 
 stop_service() {
 	log "stop: begin"
-	# Report dataplane state so an operator can see if a reboot
-	# is needed before next start.
+	# Pre-stop dataplane snapshot only. Real netns/veth cleanup
+	# runs in daed-guard's post-exit path after the child exits.
+	# Calling daed_cleanup_runtime here while daed is still alive
+	# is a no-op (pgrep hits -> early return under
+	# DAED_GUARD_CLEANUP=start) and a "post-cleanup" log would
+	# falsely imply cleanup already ran. kenzok8 review on
+	# kenzok8/openwrt-daede#70.
 	local pinned="" ns_left=""
 	if [ -d /sys/fs/bpf/daed ]; then
 		pinned=$(ls /sys/fs/bpf/daed 2>/dev/null | tr '\n' ' ')
@@ -97,19 +101,7 @@ stop_service() {
 	if ip netns list 2>/dev/null | grep -q '^daens'; then
 		ns_left="daens"
 	fi
-	log "stop: pre-cleanup state — bpf_pinned=[${pinned:-none}] netns_left=[${ns_left:-none}]"
-
-	daed_cleanup_runtime
-
-	pinned=""
-	ns_left=""
-	if [ -d /sys/fs/bpf/daed ]; then
-		pinned=$(ls /sys/fs/bpf/daed 2>/dev/null | tr '\n' ' ')
-	fi
-	if ip netns list 2>/dev/null | grep -q '^daens'; then
-		ns_left="daens"
-	fi
-	log "stop: post-cleanup state — bpf_pinned=[${pinned:-none}] netns_left=[${ns_left:-none}]"
+	log "stop: pre-stop state — bpf_pinned=[${pinned:-none}] netns_left=[${ns_left:-none}]"
 }
 
 restart() {


### PR DESCRIPTION
## 变更

- 启动前和子进程退出后清理残留的 `daens` / `dae0`；检测到现有 daed 或进程探测异常时 fail closed。
- 转发 `TERM`、`INT`、`HUP`、`QUIT`，并处理 child PID 建立前收到停止信号的竞态。
- guard 在 `TERM` / `INT` / `QUIT` 后最多等待 20 秒，随后发送 `KILL` 并 `wait` 回收子进程；procd 的 `term_timeout` 设为 30 秒。
- 保留 daed 原始退出码；仅在 daed 正常退出时返回 post-exit cleanup 错误。
- 将 `/sys/fs/bpf/daed` 视为正常持久 pin root，不删除，也不作为启动失败条件。
- 使用 rc.common / procd 原生 restart 流程，包版本升至 `2026.09.06-r3`。

## 边界

- 包脚本只清理 netns / veth；TC detach 仍由 daed 自身的优雅退出路径负责。
- pin 目录存在不能证明 TC hook 仍然泄漏。

## 验证

- `git diff --check`、`sh -n`、`dash -n` 通过。
- dash 行为测试覆盖退出码 0/7、HUP、TERM/INT/QUIT、pending-signal 竞态、忽略 TERM 后强制 KILL/回收，以及 cleanup / probe fail closed。
- [GitHub Actions Test daed build](https://github.com/kenzok8/openwrt-daede/actions/runs/34749686712) 的 4 个构建矩阵全部通过。
- 在 252（ImmortalWrt 25.12 x86_64）实机完成 r2 → r3 升级、BusyBox ash 行为测试、`start → stop → start → restart ×3` 和连续快速 `restart ×3`；运行期间始终只有 1 个真实 daed 和 1 个 guard，父子关系正确，停止后 netns / veth 已清理。
