### PR TITLE
fix: daed 连不上 Xray-core 26.7.x 服务端（REALITY 默认 minClientVer 门槛）——补 outbound 版本字节

### DIFF
--- a/ci/PERF-PATCHES.md
+++ b/ci/PERF-PATCHES.md
@@ -22,18 +22,20 @@ fix onto this lineage.
 
 ## Self-owned patches that must survive every sync
 
-The repository currently carries 17 patch files:
+The repository currently carries 18 patch files:
 
 - `dae/patches`: 1 regular dae patch.
 - `dae/patches_arm`: 2 ARM32 compatibility patches.
 - `daed/patches`: 11 daed reliability and update patches.
 - `daed/patches_arm`: 2 ARM32 compatibility patches for the embedded dae core.
-- `ci/patches/outbound`: 1 SSR buffered-reader fix.
+- `ci/patches/outbound`: 2 patches (SSR buffered-reader fix + temporary REALITY
+  client-version bump for Xray-core 26.7.x, see `ci/patches/outbound/README.md`).
 - `ci/patches/quic-go`: currently empty; retained for future backports.
 
-On 2026-08-28 every patch was checked against the pinned upstream source. None
-was equivalently absorbed, and all 17 remain required. In particular, outbound
-still lacks the SSR `unwrapConn` fix.
+On 2026-08-28 every patch then present was checked against the pinned upstream
+source. None was equivalently absorbed, and all of them remain required. In
+particular, outbound still lacks the SSR `unwrapConn` fix and a native REALITY
+version-byte strategy.
 
 The `patch-absorbed` job in `auto-bump.yml` checks every regular, ARM, outbound
 and quic-go patch in package order. It reports a patch when reverse apply starts
@@ -59,7 +61,7 @@ upstream before deleting a reported local patch.
 5. After the mirror and patch audit succeed, update `OUTBOUND_COMMIT`,
    `QUICGO_BASE_COMMIT` and `QUICGO_PERF_TIP` together in `ci/pins.env`.
 6. For outbound, apply `ci/patches/outbound/*.patch` and run
-   `go test ./protocol/shadowsocks_stream/`.
+   `go test ./protocol/shadowsocks_stream/ ./transport/tls/`.
 7. For quic-go, apply any `ci/patches/quic-go/*.patch` and run `go build ./...`.
 8. On a staging branch, run both assemble workflows and all four gate build
    combinations (2 SDK versions × 2 architectures). Promote to `main` only

--- a/ci/patches/outbound/0002-reality-client-version.patch
+++ b/ci/patches/outbound/0002-reality-client-version.patch
@@ -1,5 +1,5 @@
 diff --git a/transport/tls/reality.go b/transport/tls/reality.go
-index 72fa32a..d293486 100644
+index 756a749..bb58754 100644
 --- a/transport/tls/reality.go
 +++ b/transport/tls/reality.go
 @@ -41,9 +41,9 @@ import (

--- a/ci/patches/outbound/README.md
+++ b/ci/patches/outbound/README.md
@@ -4,11 +4,12 @@ Fixes we carry on top of `OUTBOUND_COMMIT` because upstream has not merged them.
 The assemble workflows apply every `NNNN-*.patch` here with `git apply` right
 after fetching outbound; an empty directory is skipped.
 
-## Current state: one patch
+## Current state: two patches
 
 | patch | what | why it is here |
 |-------|------|----------------|
 | 0001 | SSR obfs reaches its cipher through `BufferedReaderConn` | fixes every SSR handshake; olicesx never merged it into `perf/complete-optimizations` |
+| 0002 | REALITY client sends version bytes `[26,7,28]` instead of `[1,8,10]` | Xray-core 26.7.11+ defaults the server's `minClientVer` to `26.3.27`, so our version bytes are rejected; see below |
 
 ### 0001 background
 
@@ -17,6 +18,28 @@ asserting on the underlying conn. A TCP read-buffering change wrapped that conn
 in `netproxy.BufferedReaderConn`, so both assertions stopped matching and every
 SSR handshake failed with `outer conn did not init cipher of Obfs` (issue #52).
 The fix peels transparent wrappers via the existing `IntrinsicConn` accessor.
+
+### 0002 background
+
+The REALITY client writes its own three version bytes into the encrypted
+handshake. Xray-core 26.7.11+ (commit `af7eb68`) defaults the server's
+`realitySettings.minClientVer` to `26.3.27` when unset, so every 26.7.x server
+rejects dae/daed REALITY connections into the fallback decoy
+(`REALITY: processed invalid connection`). Sending `[26,7,28]` passes any
+current default gate. This is a temporary compatibility measure, not a protocol
+requirement:
+
+- Xray-core main has already reverted the default gate in commit `47cfe999`,
+  but no release carries that change yet, and 26.7.x servers already deployed
+  keep it.
+- Re-evaluate (and delete) this patch only when outbound itself adopts an
+  appropriate version-byte strategy, or when the project's compatibility scope
+  explicitly drops 26.7.x servers — not merely because a newer Xray release
+  appears. A server operator can still reject us by explicitly configuring a
+  lower `maxClientVer`; that is their choice and nothing on our side fixes it.
+
+The REALITY protocol library is identical between Xray-core 26.3.27 and
+26.7.28, so patched clients remain fully compatible with older servers.
 
 The fix exists upstream as a side commit (`d5d9708`, later rebased to
 `5797872`) that was never merged into the perf branch we track. Pinning

--- a/ci/patches/outbound/README.md
+++ b/ci/patches/outbound/README.md
@@ -19,12 +19,25 @@ in `netproxy.BufferedReaderConn`, so both assertions stopped matching and every
 SSR handshake failed with `outer conn did not init cipher of Obfs` (issue #52).
 The fix peels transparent wrappers via the existing `IntrinsicConn` accessor.
 
+The fix exists upstream as a side commit (`d5d9708`, later rebased to
+`5797872`) that was never merged into the perf branch we track. Pinning
+`OUTBOUND_COMMIT` at that side commit does not survive: `auto-bump.yml` runs
+`gh repo sync ... --force`, which resets our fork's branch to olicesx's, and the
+next bump moves `OUTBOUND_COMMIT` to a perf-branch commit without the fix. That
+is exactly how it regressed on 2026-08-13 (`dae/daed 2026.08.13`) — the same
+breakage as #52, five days after it was first fixed. Carrying it as a patch here
+decouples the fix from both the fork branch and the pin.
+
+The patch ships `ssr_cipher_test.go` with it:
+`TestSSRObfsReceivesCipherThroughBufferedReaderConn` fails on an unpatched tree
+and passes on a patched one, so a silent regression cannot come back unnoticed.
+
 ### 0002 background
 
 The REALITY client writes its own three version bytes into the encrypted
 handshake. Xray-core 26.7.11+ (commit `af7eb68`) defaults the server's
-`realitySettings.minClientVer` to `26.3.27` when unset, so every 26.7.x server
-rejects dae/daed REALITY connections into the fallback decoy
+`realitySettings.minClientVer` to `26.3.27` when unset, so 26.7.x servers using
+that default reject dae/daed REALITY connections into the fallback decoy
 (`REALITY: processed invalid connection`). Sending `[26,7,28]` passes any
 current default gate. This is a temporary compatibility measure, not a protocol
 requirement:
@@ -41,28 +54,16 @@ requirement:
 The REALITY protocol library is identical between Xray-core 26.3.27 and
 26.7.28, so patched clients remain fully compatible with older servers.
 
-The fix exists upstream as a side commit (`d5d9708`, later rebased to
-`5797872`) that was never merged into the perf branch we track. Pinning
-`OUTBOUND_COMMIT` at that side commit does not survive: `auto-bump.yml` runs
-`gh repo sync ... --force`, which resets our fork's branch to olicesx's, and the
-next bump moves `OUTBOUND_COMMIT` to a perf-branch commit without the fix. That
-is exactly how it regressed on 2026-08-13 (`dae/daed 2026.08.13`) — the same
-breakage as #52, five days after it was first fixed. Carrying it as a patch here
-decouples the fix from both the fork branch and the pin.
-
-The patch ships `ssr_cipher_test.go` with it:
-`TestSSRObfsReceivesCipherThroughBufferedReaderConn` fails on an unpatched tree
-and passes on a patched one, so a silent regression cannot come back unnoticed.
-
 ## Apply by hand
 
 ```sh
 git checkout -B carry <OUTBOUND_COMMIT>
 git apply ci/patches/outbound/*.patch
-go test ./protocol/shadowsocks_stream/
+go test ./protocol/shadowsocks_stream/ ./transport/tls/
 ```
 
-## When upstream absorbs it
+## When upstream absorbs a patch
 
-`git apply` fails loudly and the assemble build stops — that is the signal to
-delete the patch file (and confirm `unwrapConn` really is in the new base).
+`git apply` fails loudly and the assemble build stops. Inspect the failing patch
+before deleting it: for 0001, confirm `unwrapConn` is in the new base; for 0002,
+follow the re-evaluation conditions above.

--- a/ci/patches/outbound/reality-clientver-26.7.28.patch
+++ b/ci/patches/outbound/reality-clientver-26.7.28.patch
@@ -1,0 +1,17 @@
+diff --git a/transport/tls/reality.go b/transport/tls/reality.go
+index 72fa32a..d293486 100644
+--- a/transport/tls/reality.go
++++ b/transport/tls/reality.go
+@@ -41,9 +41,9 @@ import (
+ )
+ 
+ var (
+-	Reality_Version_x byte = 1
+-	Reality_Version_y byte = 8
+-	Reality_Version_z byte = 10
++	Reality_Version_x byte = 26
++	Reality_Version_y byte = 7
++	Reality_Version_z byte = 28
+ )
+ 
+ //go:linkname aesgcmPreferred github.com/refraction-networking/utls.aesgcmPreferred


### PR DESCRIPTION
## 问题：dae / daed 连不上任何 Xray-core 26.7.x 服务端

Xray-core 26.7.11 起（commit [af7eb68](https://github.com/XTLS/Xray-core/commit/af7eb68028732a8ee3c0e5d6ab2b8a657bb2e770)，**没有任何 release notes 公告**），REALITY 服务端 `realitySettings.minClientVer` 未显式配置时的默认值从"不启用"改为 **`26.3.27`**。REALITY 客户端在握手的加密 session_id 明文里携带 3 字节客户端版本号，服务端做下限比较，低于门槛的连接全部被踢去伪装回落（服务端日志 `REALITY: processed invalid connection`）。

dae 的 REALITY 客户端在 outbound 库（`transport/tls/reality.go`），发送的是 outbound 自身的版本号常量 `[1,8,10]`，`[1,8,10] < [26,3,27]`，所以 **dae 与 daed 两个包（都内嵌 outbound）**的所有 vless+reality 节点在 26.7.x 默认配置的服务端上必死。同类受害者：mihomo（XTLS/Xray-core #6477）、Shadowrocket/Karing（#6482/#6542/#6728）、老客户端触发入站 ~15 分钟不可用（#6577）。

## 补丁（按 review 意见重组）

- `ci/patches/outbound/0002-reality-client-version.patch`：基于当前 `OUTBOUND_COMMIT=13b8501`（blob `756a749`）重新生成，文件名按 `NNNN-*.patch` 约定、不绑定具体版本值。常量提到 `[26,7,28]`——通过任何现存默认门槛。
- **边界说明（更正首版正文的"无 maxClientVer 副作用"表述）**：服务端同时支持 `minClientVer` 与 `maxClientVer` 两个检查，默认配置只设了 min 没设 max，所以 `[26,7,28]` 在默认配置下无版本上限问题；但管理员**显式配置了更低 `maxClientVer`** 的服务端仍会拒绝，这属于服务端运营者的选择，客户端无法满足。
- **兼容性无忧**：26.3.27↔26.7.28 的 XTLS/REALITY 协议库一行未动（同 `9234c77`），打补丁的客户端连 26.3.27 及更老服务端完全正常。
- 文档：`ci/patches/outbound/README.md` 增加 0002 条目与背景（Current state: two patches）；`ci/PERF-PATCHES.md` 补丁总数 17→18、outbound 1→2，outbound 刷新测试步骤补上 `go test ./transport/tls/`。本 PR **不含任何 Makefile 改动**（source/hash/release 由对应 workflow 自动回写）。

## 重评估条件（何时删除本补丁）

- Xray-core main 已在 [47cfe999](https://github.com/XTLS/Xray-core/commit/47cfe999) 撤销了默认 `minClientVer` 门槛（把 af7eb68 写入的 `[]byte{26,3,27}` 默认值连同两条警告日志一起注释），但**当前任何正式版都未包含该修改**，已部署的 26.7.x 服务端仍带门槛。
- 因此不能仅凭"新版 Xray 发布"就删补丁；重新评估的条件是：①outbound 上游是否已原生处理版本字节，或 ②本项目兼容范围是否明确放弃 26.7.x 服务端。上游吸收后 `git apply` 会大声失败、`patch-absorbed` 任务也会报告，届时可安全删除。

## 实测（2026-09-07/08）

测试台：xray 26.7.28 服务端双入站 A（默认门槛）/ B（`minClientVer: "0.0.0"`），服务端 `show: true` 确认 dae 握手解密/时间戳/shortId 全部正确、唯一失败的就是版本比较：

| 客户端 | 发送 ClientVer | A 默认门槛 | B 无门槛 |
|---|---|---|---|
| xray 26.7.28 | [26,7,28] | ✅ | ✅ |
| xray 25.8.29 | [25,8,29] | ❌ 回落 | ✅ |
| daed 2026.08.28-r3（未打补丁） | [1,8,10] | ❌ processed invalid connection | ✅ |
| daed 2026.08.28-r4（本补丁构建） | [26,7,28] | ✅ | ✅ |

真机：VPS 升 26.7.28 后，本补丁构建的 daed 连 reality:20894 **alive 928ms**，hy2 正常，服务端日志零 `processed invalid connection`。

## 双包 assemble 验证

outbound 同时被 dae 与 daed 内嵌，两条 assemble 流水线均已在当前 pins（`OUTBOUND_COMMIT=13b8501`）上验证通过：

- [assemble-dae-src ✅](https://github.com/Bernardxu123/openwrt-daede/actions/runs/34235906037)
- [assemble-daed-src ✅](https://github.com/Bernardxu123/openwrt-daede/actions/runs/34236413007)

Fixes #73
